### PR TITLE
Migrating from master/slave words

### DIFF
--- a/src/sage/interfaces/expect.py
+++ b/src/sage/interfaces/expect.py
@@ -336,7 +336,7 @@ class Expect(ParentWithBase):
 
     def _install_hints(self):
         r"""
-        Hints for installing needed slave program on your computer.
+        Hints for installing needed subordinate program on your computer.
         
         There are no hints by default.
         """
@@ -349,17 +349,17 @@ class Expect(ParentWithBase):
         """
         # Written by Paul-Olivier Dehaye 2007/08/23
         return """ 
-In order for Sage (on "local") to launch a "slave" process on "remote", the following command needs to work from local's console, without the need to enter any password:
+In order for Sage (on "local") to launch a "subordinate" process on "remote", the following command needs to work from local's console, without the need to enter any password:
 
-       "ssh -t remote slave",
+       "ssh -t remote subordinate",
 
-where "slave" could be "math" (for text-mode Mathematica), "gap", "magma", "sage", "maple", etc.
+where "subordinate" could be "math" (for text-mode Mathematica), "gap", "magma", "sage", "maple", etc.
 
 This thus requires passwordless authentication to be setup, which can be done with commands like these:
         cd; ssh-keygen -t rsa; scp .ssh/id_rsa.pub remote:.ssh/authorized_keys2\n
 (WARNING: this would overwrite your current list of auhorized keys on "remote")
 
-In many cases, the server that can actually run "slave" is not accessible from the internet directly, but you have to hop through an intermediate trusted server, say "gate".
+In many cases, the server that can actually run "subordinate" is not accessible from the internet directly, but you have to hop through an intermediate trusted server, say "gate".
 If that is your case, get help with _install_hints_ssh_through_gate().
 
 """
@@ -371,9 +371,9 @@ If that is your case, get help with _install_hints_ssh_through_gate().
         # Written by Paul-Olivier Dehaye 2007/08/23
         return """
 
- We assume you would like to run a "slave" process  on a machine called "remote" from a machine running SAGE called "local". We also assume "remote" can only be accessed from "local" by ssh'ing first to "gate" (this is a fairly common setup). Sometimes, "gate" and "remote" haved a shared filesystem, and this helps a bit.
+ We assume you would like to run a "subordinate" process  on a machine called "remote" from a machine running SAGE called "local". We also assume "remote" can only be accessed from "local" by ssh'ing first to "gate" (this is a fairly common setup). Sometimes, "gate" and "remote" haved a shared filesystem, and this helps a bit.
 
-  Note: You cannot just create shell scripts on "local" and "gate" that would use two successive SSH connections to "remote" in order to simulate running "slave" locally. This is because SAGE will sometimes use files (and scp)  to communicate with "remote", which shell scripts would not take care of. 
+  Note: You cannot just create shell scripts on "local" and "gate" that would use two successive SSH connections to "remote" in order to simulate running "subordinate" locally. This is because SAGE will sometimes use files (and scp)  to communicate with "remote", which shell scripts would not take care of. 
 
 You need to setup:
  * passwordless authentication to "gate" from "local"

--- a/src/sage/interfaces/rubik.py
+++ b/src/sage/interfaces/rubik.py
@@ -61,7 +61,7 @@ optimal_solver_format = "UF UR UB UL DF DR DB DL FR FL BR BL UFR URB UBL ULF DRF
 
 class SingNot:
     """
-    This class is to resolve difference between various Singmaster notation. 
+    This class is to resolve difference between various Singmain notation. 
     Case is ignored, and the second and third letters may be swapped. 
     
     EXAMPLE: 
@@ -82,7 +82,7 @@ class SingNot:
         return hash(self.canonical)
 
 # This is our list
-singmaster_list = [''] + [SingNot(index2singmaster(i+1)) for i in range(48)]; singmaster_list                        
+singmain_list = [''] + [SingNot(index2singmain(i+1)) for i in range(48)]; singmain_list                        
 
 class OptimalSolver:
     """
@@ -152,8 +152,8 @@ class OptimalSolver:
         L = []
         optimal_solver_list = [SingNot(x) for x in optimal_solver_tokens]
         for f in optimal_solver_format.split(" "):
-            ix = facets[singmaster_list.index(SingNot(f))-1]
-            facet = singmaster_list[ix]
+            ix = facets[singmain_list.index(SingNot(f))-1]
+            facet = singmain_list[ix]
             L.append(optimal_solver_list[optimal_solver_list.index(facet)])
         return " ".join([str(f) for f in L])        
         

--- a/src/sage/misc/darcs.py
+++ b/src/sage/misc/darcs.py
@@ -82,7 +82,7 @@ class Darcs:
             dir -- directory that will contain the repository
             name -- a friendly name for the repository (only used for printing)
             url -- a default URL to pull or record sends against (e.g.,
-                   this could be a master repository on modular.math.washington.edu)
+                   this could be a main repository on modular.math.washington.edu)
             target -- if the last part of dir is, e.g., sage-darcs,
                       create a symlink from sage-darcs to target.
                       If target=None, this symlink will not be created.
@@ -203,7 +203,7 @@ class Darcs:
 
     def url(self):
         """
-        Return the default 'master url' for this repository.
+        Return the default 'main url' for this repository.
         """
         return self.__url
 

--- a/src/sage/misc/hg.py
+++ b/src/sage/misc/hg.py
@@ -102,7 +102,7 @@ class HG:
           printing)
         
         - ``pull_url`` - a default URL to pull or record sends against
-          (e.g., this could be a master repository on
+          (e.g., this could be a main repository on
           modular.math.washington.edu)
         
         - ``push_url`` - a default URL to push or record outgoing
@@ -719,7 +719,7 @@ class HG:
 
     def pull_url(self):
         """
-        Return the default 'master url' for this repository.
+        Return the default 'main url' for this repository.
         """
         return self.__pull_url
 

--- a/src/sage/misc/sage_input.py
+++ b/src/sage/misc/sage_input.py
@@ -1953,8 +1953,8 @@ class SIE_dict(SageInputExpression):
             sage: from sage.misc.sage_input import SageInputBuilder
 
             sage: sib = SageInputBuilder()
-            sage: sib.dict({'keaton':'general', 'chan':'master'})
-            {dict: {{atomic:'keaton'}:{atomic:'general'}, {atomic:'chan'}:{atomic:'master'}}}
+            sage: sib.dict({'keaton':'general', 'chan':'main'})
+            {dict: {{atomic:'keaton'}:{atomic:'general'}, {atomic:'chan'}:{atomic:'main'}}}
         """
         return "{dict: {%s}}" % \
             ', '.join([repr(key) + ':' + repr(val)


### PR DESCRIPTION
For diversity reasons, it would be nice to try to avoid 'master' and 'slave' terminology in this repository which can be associated to slavery. The master-slave terminology could be problematic for people in several countries which has the history of slavery like Romania, USA and many others. Thank you for considering the proposal. Let me know if any changes in the PR are needed, I would be happy to implement them.